### PR TITLE
fix: harden update checks, IPC, and frontend from code review

### DIFF
--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -65,6 +65,16 @@ fn looks_like_version(s: &str) -> bool {
     s.contains('-') && s.chars().any(|c| c.is_ascii_digit())
 }
 
+/// Valid pacman/AUR package names use only `[A-Za-z0-9@._+-]` (per libalpm), so
+/// any token with other characters isn't a real package. Rejecting it here is
+/// what keeps shell metacharacters out of the `yay -S`/`pacman -S` command
+/// strings built downstream (some of which run through `bash -c`/ssh shells).
+fn looks_like_package_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '@' | '.' | '_' | '+' | '-'))
+}
+
 /// Parse "package old_version -> new_version" lines into UpdateInfo list.
 /// The arrow is located by search rather than fixed position so annotations
 /// around the versions — e.g. the time-since-release marker yay 13+ appends
@@ -81,6 +91,9 @@ pub fn parse_update_output(output: &str) -> Vec<UpdateInfo> {
             let old_version = parts[arrow - 1];
             let new_version = parts[arrow + 1];
             if !looks_like_version(old_version) || !looks_like_version(new_version) {
+                return None;
+            }
+            if !looks_like_package_name(parts[0]) {
                 return None;
             }
             Some(UpdateInfo {
@@ -340,6 +353,14 @@ mod tests {
         // ≥5-token noise shaped "word word -> word junk" must not become an
         // update — fake package names would reach shell commands downstream.
         let out = "warning: database -> outdated (run pacman -Sy)\nfoo bar -> baz qux\n";
+        assert!(parse_update_output(out).is_empty());
+    }
+
+    #[test]
+    fn rejects_package_names_with_shell_metacharacters() {
+        // A name carrying shell metacharacters must never become an update —
+        // it would otherwise flow unquoted into `yay -S`/`pacman -S` shells.
+        let out = "openssl;reboot 1.0-1 -> 1.1-1\n$(id) 1.0-1 -> 1.1-1\na`b` 1.0-1 -> 1.1-1\n";
         assert!(parse_update_output(out).is_empty());
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -75,7 +75,9 @@ pub async fn get_check_result(
 ) -> Result<Option<FullCheckResult>, String> {
     let local = tray_state.local_result.read().await.clone();
     let remote = tray_state.remote_results.read().await.clone();
-    if local.is_none() {
+    // Surface results if either side has data — a failed local check must not
+    // hide successfully-scanned remote hosts (the frontend handles a null local).
+    if local.is_none() && remote.is_empty() {
         return Ok(None);
     }
     Ok(Some(FullCheckResult { local, remote }))

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -27,8 +27,6 @@ pub struct AppConfig {
     pub autostart: bool,
     #[serde(default = "default_true")]
     pub animations: bool,
-    #[serde(default = "default_recheck")]
-    pub recheck_interval_minutes: u32,
     #[serde(default)]
     pub passwordless_updates: bool,
     #[serde(default)]
@@ -44,8 +42,6 @@ pub struct AppConfig {
     #[serde(default)]
     pub tailscale_ssh_user: String,
     #[serde(default)]
-    pub vertical_update_tabs: bool,
-    #[serde(default)]
     pub scheduled_check_enabled: bool,
     #[serde(default = "default_sched_day")]
     pub scheduled_check_day: u32,
@@ -56,7 +52,6 @@ pub struct AppConfig {
 fn default_interval() -> u32 { 60 }
 fn default_notify() -> String { "new_only".into() }
 fn default_true() -> bool { true }
-fn default_recheck() -> u32 { 5 }
 fn default_theme() -> String { "default".into() }
 fn default_tags() -> String { "server,arch".into() }
 fn default_timeout() -> u32 { 10 }
@@ -75,14 +70,12 @@ impl Default for AppConfig {
             autostart: false,
             animations: true,
             theme: "default".into(),
-            recheck_interval_minutes: 5,
             passwordless_updates: false,
             restart_delay_seconds: 0,
             tailscale_enabled: false,
             tailscale_tags: "server,arch".into(),
             tailscale_timeout: 10,
             tailscale_ssh_user: String::new(),
-            vertical_update_tabs: false,
             scheduled_check_enabled: false,
             scheduled_check_day: 5,
             scheduled_check_time: "02:00".into(),

--- a/src-tauri/src/icons.rs
+++ b/src-tauri/src/icons.rs
@@ -1,21 +1,24 @@
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use tauri::image::Image;
 
 const SIZE: u32 = 64;
 
-/// Lazily-initialized font database with system fonts loaded.
-fn fontdb() -> &'static resvg::usvg::fontdb::Database {
-    static DB: OnceLock<resvg::usvg::fontdb::Database> = OnceLock::new();
+/// Lazily-initialized font database with system fonts loaded, kept behind an
+/// `Arc` so each render cheaply clones the handle instead of deep-copying the
+/// whole (tens-of-MB) system font database on every tray icon render.
+fn fontdb() -> Arc<resvg::usvg::fontdb::Database> {
+    static DB: OnceLock<Arc<resvg::usvg::fontdb::Database>> = OnceLock::new();
     DB.get_or_init(|| {
         let mut db = resvg::usvg::fontdb::Database::new();
         db.load_system_fonts();
-        db
+        Arc::new(db)
     })
+    .clone()
 }
 
 fn render_svg(svg: &str) -> Image<'static> {
     let mut opt = resvg::usvg::Options::default();
-    opt.fontdb = std::sync::Arc::new(fontdb().clone());
+    opt.fontdb = fontdb();
     let tree = resvg::usvg::Tree::from_str(svg, &opt).expect("Failed to parse SVG");
     let size = tree.size();
     let mut pixmap =

--- a/src-tauri/src/tailscale.rs
+++ b/src-tauri/src/tailscale.rs
@@ -187,41 +187,55 @@ async fn check_host(hostname: &str, timeout: u32, ssh_user: &str) -> HostResult 
     };
 
     match ssh_run(&target, "checkupdates", timeout).await {
-        Ok(output) => {
-            // checkupdates: exit 0 = updates, exit 2 = no updates
-            if output.status.success() {
+        // checkupdates exit codes: 0 = updates available, 2 = no updates, and
+        // anything else is a real failure (1 = checkupdates error, 255 = ssh
+        // could not connect/authenticate). Mirror the local checker's handling
+        // so a dead or misconfigured host reports an error rather than silently
+        // showing as "up to date".
+        Ok(output) => match output.status.code() {
+            Some(0) => {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                if !stdout.trim().is_empty() {
-                    let mut updates = parse_update_output(&stdout);
-                    let running_pkg = remote_kernel_package(&target, &updates, timeout).await;
+                if stdout.trim().is_empty() {
+                    return empty(None);
+                }
+                let mut updates = parse_update_output(&stdout);
+                let running_pkg = remote_kernel_package(&target, &updates, timeout).await;
 
-                    // Enrich with source repo + package URL (checkupdates omits these).
-                    let pkg_names: Vec<String> =
-                        updates.iter().map(|u| u.package.clone()).collect();
-                    let repos = remote_repositories(&target, &pkg_names, timeout).await;
-                    for u in &mut updates {
-                        if let Some((repo, arch)) = repos.get(&u.package) {
-                            u.repository = repo.clone();
-                            u.url = package_url(repo, arch, &u.package);
-                        }
+                // Enrich with source repo + package URL (checkupdates omits these).
+                let pkg_names: Vec<String> = updates.iter().map(|u| u.package.clone()).collect();
+                let repos = remote_repositories(&target, &pkg_names, timeout).await;
+                for u in &mut updates {
+                    if let Some((repo, arch)) = repos.get(&u.package) {
+                        u.repository = repo.clone();
+                        u.url = package_url(repo, arch, &u.package);
                     }
+                }
 
-                    let restart_pkgs: Vec<String> = updates
-                        .iter()
-                        .filter(|u| package_requires_restart(&u.package, running_pkg.as_deref()))
-                        .map(|u| u.package.clone())
-                        .collect();
-                    return HostResult {
-                        hostname: hostname.to_string(),
-                        needs_restart: !restart_pkgs.is_empty(),
-                        restart_packages: restart_pkgs,
-                        updates,
-                        error: None,
-                    };
+                let restart_pkgs: Vec<String> = updates
+                    .iter()
+                    .filter(|u| package_requires_restart(&u.package, running_pkg.as_deref()))
+                    .map(|u| u.package.clone())
+                    .collect();
+                HostResult {
+                    hostname: hostname.to_string(),
+                    needs_restart: !restart_pkgs.is_empty(),
+                    restart_packages: restart_pkgs,
+                    updates,
+                    error: None,
                 }
             }
-            empty(None)
-        }
+            Some(2) => empty(None),
+            Some(255) => empty(Some("SSH connection failed".to_string())),
+            _ => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let msg = stderr.trim();
+                empty(Some(if msg.is_empty() {
+                    "checkupdates failed".to_string()
+                } else {
+                    format!("checkupdates error: {msg}")
+                }))
+            }
+        },
         Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
             empty(Some("Connection timed out".to_string()))
         }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -202,10 +202,17 @@ pub fn start_periodic_check(app_handle: tauri::AppHandle) {
 
             if interval_enabled {
                 let last = *app_handle.state::<TrayState>().last_check.read().await;
-                if let Some(last) = last {
-                    if now - last >= chrono::Duration::minutes(interval_min as i64) {
-                        fire = true;
+                match last {
+                    Some(last) => {
+                        if now - last >= chrono::Duration::minutes(interval_min as i64) {
+                            fire = true;
+                        }
                     }
+                    // No successful check has ever landed (e.g. the startup check
+                    // errored transiently), so `last_check` is still None. Retry
+                    // each tick until one succeeds instead of sitting on the
+                    // error icon forever.
+                    None => fire = true,
                 }
             }
 
@@ -350,6 +357,11 @@ pub async fn start_check(app_handle: tauri::AppHandle) {
         }
         Err(err) => {
             log::error!("Update check failed: {err}");
+            // The remote scan already completed before the local check was
+            // evaluated — keep its results so the Updates window can still show
+            // remote hosts even though the local check errored.
+            *tray_state.remote_results.write().await = remote_hosts.clone();
+            *tray_state.last_check.write().await = Some(chrono::Local::now());
             let _ = app_handle.emit("check-error", &err);
             update_tray_error(&app_handle);
         }
@@ -368,7 +380,14 @@ async fn handle_update_finished(app_handle: tauri::AppHandle, scope: String) {
             let result = tray_state.local_result.read().await;
             result
                 .as_ref()
-                .map(|r| r.updates.iter().any(|u| u.package == "yay-sys-tray-git"))
+                .map(|r| {
+                    r.updates.iter().any(|u| {
+                        matches!(
+                            u.package.as_str(),
+                            "yay-sys-tray-git" | "yay-sys-tray-bin" | "yay-sys-tray"
+                        )
+                    })
+                })
                 .unwrap_or(false)
         };
         if self_update {
@@ -555,28 +574,22 @@ async fn update_tray_state(
     let tray_state = app_handle.state::<TrayState>();
     tray_state.reset_bounce();
 
-    if total_count == 0 && reboot_needed {
-        let icon = icons::create_reboot_icon();
-        if animations {
-            start_bounce_animation(app_handle.clone(), icon, 1000, 16);
-        } else {
-            let _ = tray.set_icon(Some(icons::create_reboot_icon()));
-        }
-    } else if total_count == 0 {
+    if total_count == 0 && !reboot_needed {
         let _ = tray.set_icon(Some(icons::create_ok_icon()));
-    } else if any_restart {
-        let icon = icons::create_restart_icon(total_count);
-        if animations {
-            start_bounce_animation(app_handle.clone(), icon, 500, 10);
-        } else {
-            let _ = tray.set_icon(Some(icons::create_restart_icon(total_count)));
-        }
     } else {
-        let icon = icons::create_updates_icon(total_count);
-        if animations {
-            start_bounce_animation(app_handle.clone(), icon, 500, 10);
+        // Pick the icon and its bounce timing once, then either animate it or set
+        // it statically — no rebuilding the same icon in both branches.
+        let (icon, interval_ms, max_ticks) = if total_count == 0 {
+            (icons::create_reboot_icon(), 1000, 16)
+        } else if any_restart {
+            (icons::create_restart_icon(total_count), 500, 10)
         } else {
-            let _ = tray.set_icon(Some(icons::create_updates_icon(total_count)));
+            (icons::create_updates_icon(total_count), 500, 10)
+        };
+        if animations {
+            start_bounce_animation(app_handle.clone(), icon, interval_ms, max_ticks);
+        } else {
+            let _ = tray.set_icon(Some(icon));
         }
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -73,15 +73,17 @@
     window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", applyTheme);
 
     const win = getCurrentWindow();
-    try {
-      scaleFactor = await win.scaleFactor();
-    } catch {}
     // Remember manual resizes per view (ignore the resizes we trigger ourselves).
-    win.onResized(({ payload }) => {
+    // Read the scale factor fresh each time — it changes when the window moves
+    // between monitors of different DPI, and a stale factor would persist a
+    // wrong (e.g. doubled) logical size.
+    win.onResized(async ({ payload }) => {
       if (suppressSave || !currentView) return;
+      let sf = scaleFactor;
+      try { sf = await win.scaleFactor(); } catch {}
       sizes[currentView] = [
-        Math.round(payload.width / scaleFactor),
-        Math.round(payload.height / scaleFactor),
+        Math.round(payload.width / sf),
+        Math.round(payload.height / sf),
       ];
       try {
         localStorage.setItem(SIZE_KEY, JSON.stringify(sizes));

--- a/src/lib/components/DependencyTree.svelte
+++ b/src/lib/components/DependencyTree.svelte
@@ -46,11 +46,19 @@
     return "var(--ys-text-muted)";
   }
 
+  let reqId = 0;
   $effect(() => {
+    // Latest-wins: toggling direction fires a new request; ignore any earlier
+    // (possibly slower, e.g. over SSH) response so it can't overwrite the tree
+    // for the direction currently selected.
+    const pkg = packageName;
+    const d = dir;
+    const host = hostname;
+    const my = ++reqId;
     loading = true;
-    getPactree(packageName, dir, hostname ?? undefined)
-      .then((r) => { tree = r; loading = false; })
-      .catch(() => { tree = "Failed to load dependency tree"; loading = false; });
+    getPactree(pkg, d, host ?? undefined)
+      .then((r) => { if (my === reqId) { tree = r; loading = false; } })
+      .catch(() => { if (my === reqId) { tree = "Failed to load dependency tree"; loading = false; } });
   });
 </script>
 

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -34,17 +34,37 @@
     }
   });
 
+  // Empty <input type="number"> fields bind to null; coerce them back to a
+  // valid integer so save_config doesn't reject on a null and leave the dialog
+  // silently stuck open.
+  function num(v: unknown, fallback: number, min: number, max: number): number {
+    const n = typeof v === "number" && !Number.isNaN(v) ? v : fallback;
+    return Math.min(max, Math.max(min, n));
+  }
+
   async function handleSave() {
     if (!config) return;
-    if (config.check_interval_minutes < 5) config.check_interval_minutes = 5;
+    config.check_interval_minutes = num(config.check_interval_minutes, 60, 5, 1440);
+    config.restart_delay_seconds = num(config.restart_delay_seconds, 0, 0, 600);
+    config.tailscale_timeout = num(config.tailscale_timeout, 10, 5, 60);
     if (config.autostart !== initial.autostart) {
       try { await manageAutostart(config.autostart); initial.autostart = config.autostart; } catch (e) { console.error(e); }
     }
     if (config.passwordless_updates !== initial.passwordless) {
-      try { await managePasswordlessUpdates(config.passwordless_updates); initial.passwordless = config.passwordless_updates; } catch (e) { console.error(e); }
+      try {
+        const ok = await managePasswordlessUpdates(config.passwordless_updates);
+        // The pkexec prompt was cancelled (or the sudoers rule wasn't written),
+        // so don't persist a setting the system can't actually honor.
+        if (config.passwordless_updates && !ok) config.passwordless_updates = false;
+        initial.passwordless = config.passwordless_updates;
+      } catch (e) { console.error(e); config.passwordless_updates = initial.passwordless; }
     }
-    await saveConfig(config);
-    onclose();
+    try {
+      await saveConfig(config);
+      onclose();
+    } catch (e) {
+      console.error("Failed to save config:", e);
+    }
   }
 </script>
 
@@ -86,7 +106,7 @@
           <ToggleSwitch bind:checked={config.check_interval_enabled} />
         </div>
 
-        <div class="grid3">
+        <div class="grid2">
           <div class="scard small">
             <div class="scard-label">NOTIFICATIONS</div>
             <select class="ys-select" bind:value={config.notify}>
@@ -98,10 +118,6 @@
           <div class="scard small">
             <div class="scard-label">TERMINAL</div>
             <input class="ys-input" type="text" bind:value={config.terminal} />
-          </div>
-          <div class="scard small">
-            <div class="scard-label">RE-CHECK</div>
-            <label class="ys-num"><input type="number" min="1" max="60" bind:value={config.recheck_interval_minutes} /><span>min</span></label>
           </div>
         </div>
 
@@ -165,14 +181,6 @@
             <label class="ys-num"><input type="number" min="5" max="60" bind:value={config.tailscale_timeout} disabled={!config.tailscale_enabled} /><span>s</span></label>
           </div>
         </div>
-
-        <div class="scard row">
-          <div class="block">
-            <div class="scard-title">Vertical tabs on the left</div>
-            <div class="scard-desc">Better for small screens</div>
-          </div>
-          <ToggleSwitch bind:checked={config.vertical_update_tabs} accent="cyan" />
-        </div>
       {/if}
     </div>
 
@@ -203,7 +211,6 @@
   .scard-desc { font-family: var(--font-body); font-size: 12px; color: var(--ys-text-muted); margin-top: 2px; }
   .scard-label { font-family: var(--font-mono); font-weight: 600; font-size: 11px; letter-spacing: 1.5px; color: var(--ys-text-dim); }
 
-  .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
   .grid2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
   .scard.small .scard-label { margin-bottom: 8px; }
   .ys-select.compact { width: auto; min-width: 120px; }

--- a/src/lib/components/UpdateCard.svelte
+++ b/src/lib/components/UpdateCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { open as openUrl } from "@tauri-apps/plugin-shell";
   import type { UpdateInfo } from "../types";
   import VersionDiff from "./VersionDiff.svelte";
 
@@ -60,9 +61,9 @@
       <svg viewBox="0 0 24 24"><path d="M12 20V7M6 12l6-6 6 6" /></svg>
     </button>
     {#if update.url}
-      <a class="icon web" href={update.url} target="_blank" rel="noopener" title="Open package page" aria-label="Open package page">
+      <button class="icon web" onclick={() => openUrl(update.url).catch((e) => console.error(e))} title="Open package page" aria-label="Open package page">
         <svg viewBox="0 0 24 24"><path d="M8 16L16 8M9 8h7v7" /></svg>
-      </a>
+      </button>
     {/if}
     {#if update.description}
       <span class="icon info-i" title={update.description} aria-label="Info">

--- a/src/lib/components/UpdatesDialog.svelte
+++ b/src/lib/components/UpdatesDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { listen } from "@tauri-apps/api/event";
   import type { CheckResult, HostResult, UpdateInfo } from "../types";
   import {
@@ -11,7 +11,6 @@
     runLocalUpdatePackages,
     runRemoteUpdatePackages,
     runUpdateSelected,
-    startCheck,
   } from "../ipc";
   import UpdateCard from "./UpdateCard.svelte";
   import Reticle from "./Reticle.svelte";
@@ -203,7 +202,11 @@
     }
 
     await loadResults();
-    const offs = await Promise.all([
+    // Register the scan-progress listeners. onMount's async return value is a
+    // Promise, which Svelte ignores for cleanup, so the unlisteners are torn
+    // down from onDestroy below instead — otherwise every reopen leaks 5
+    // handlers that keep firing into destroyed instances.
+    unlisteners = await Promise.all([
       listen<{ hosts: { key: string; name: string }[] }>("check-started", (e) =>
         beginChecking(e.payload.hosts),
       ),
@@ -227,8 +230,10 @@
         loadResults();
       }),
     ]);
-    return () => offs.forEach((un) => un());
   });
+
+  let unlisteners: Array<() => void> = [];
+  onDestroy(() => unlisteners.forEach((un) => un()));
 
   async function loadResults() {
     loading = true;
@@ -256,7 +261,17 @@
   }
 
   function toggleSelectAll() {
-    selectedByHost[activeKey] = allSelected ? [] : [...visiblePkgs];
+    // Only add/remove the packages currently visible under the search filter —
+    // selections of filtered-out packages must survive so "Update Selected"
+    // acts on the full set the user built, not just what's on screen.
+    const cur = selectedByHost[activeKey] ?? [];
+    if (allSelected) {
+      selectedByHost[activeKey] = cur.filter((p) => !visiblePkgs.includes(p));
+    } else {
+      const set = new Set(cur);
+      for (const p of visiblePkgs) set.add(p);
+      selectedByHost[activeKey] = [...set];
+    }
   }
 
   function handleRemove(pkg: string, flags: string) {
@@ -468,7 +483,15 @@
   <DependencyTree packageName={showDeps.pkg} reverse={showDeps.reverse} repository={showDeps.repo} hostname={showDeps.host} onclose={() => (showDeps = null)} />
 {/if}
 
-<svelte:window onkeydown={(e) => e.key === "Escape" && onclose()} />
+<svelte:window
+  onkeydown={(e) => {
+    if (e.key !== "Escape") return;
+    // Dismiss the dependency-tree overlay first if it's open, rather than
+    // hiding the whole window out from under it.
+    if (showDeps) showDeps = null;
+    else onclose();
+  }}
+/>
 
 <style>
   .dialog {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -9,10 +9,6 @@ export async function saveConfig(config: AppConfig): Promise<void> {
   return invoke("save_config", { config });
 }
 
-export async function startCheck(): Promise<void> {
-  return invoke("start_check");
-}
-
 export async function getCheckResult(): Promise<FullCheckResult | null> {
   return invoke("get_check_result");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,14 +43,12 @@ export interface AppConfig {
   autostart: boolean;
   animations: boolean;
   theme: string;
-  recheck_interval_minutes: number;
   passwordless_updates: boolean;
   restart_delay_seconds: number;
   tailscale_enabled: boolean;
   tailscale_tags: string;
   tailscale_timeout: number;
   tailscale_ssh_user: string;
-  vertical_update_tabs: boolean;
   scheduled_check_enabled: boolean;
   scheduled_check_day: number;
   scheduled_check_time: string;

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -20,9 +20,9 @@ const mkUpdates = () => [
 const config = {
   check_interval_enabled: true, check_interval_minutes: 60, notify: "never", terminal: "kitty",
   noconfirm: true, hold_terminal: true, autostart: true, animations: true, theme: "dark",
-  recheck_interval_minutes: 5, passwordless_updates: true, restart_delay_seconds: 30,
+  passwordless_updates: true, restart_delay_seconds: 30,
   tailscale_enabled: true, tailscale_tags: "arch,linux,server", tailscale_timeout: 10,
-  tailscale_ssh_user: "skint007", vertical_update_tabs: true,
+  tailscale_ssh_user: "skint007",
   scheduled_check_enabled: true, scheduled_check_day: 4, scheduled_check_time: "18:00",
 };
 


### PR DESCRIPTION
Applies fixes from a full-codebase review (11 correctness bugs + 4 cleanups). Rust compiles, all 6 Rust tests pass (including a new shell-injection guard), \`svelte-check\` is clean, and the Vite build succeeds.

## Correctness
1. **Shell injection** — a package name surviving the version-shape heuristic (e.g. \`openssl;reboot\`) flowed unquoted into \`bash -c\` / \`ssh … "sudo pacman -S …"\`. Now rejected at the parser (names must be \`[A-Za-z0-9@._+-]\`), with a test.
2. **Remote failures masked as "up to date"** — any non-zero \`checkupdates\`/ssh exit fell through to *0 updates, no error*. Now distinguishes exit 2 (none), 255 (SSH failure), and real errors.
3. **Local failure hid remote results** — the \`Err\` arm dropped the completed remote scan and \`get_check_result\` returned \`None\` whenever local was \`None\`. Remote results are now preserved and surfaced.
4. **No auto-retry after a failed startup check** — \`last_check\` stayed \`None\` so the interval tick never fired. Now retries each tick until one succeeds.
5. **Listener leak** — async \`onMount\`'s returned cleanup is ignored by Svelte; moved teardown to \`onDestroy\`.
6. **Settings Save silently failed** — empty numeric field → \`null\` → unhandled reject; also persisted \`passwordless=true\` on a cancelled pkexec prompt. Now coerces numbers, honors \`Ok(false)\`, and catches errors.
7. **Select-all dropped filtered selections** — now unions/subtracts only the visible set.
8. **Self-update restart only for \`-git\`** — now also matches \`-bin\` and the base name.
9. Escape closes the dependency-tree overlay before hiding the window.
10. Dependency tree has a latest-wins guard against stale responses.
11. Window resize reads a fresh scale factor for correct multi-monitor sizes; package-page link opens via the shell plugin instead of a dead \`target=_blank\` anchor.

## Cleanup
- Removed dead config fields \`recheck_interval_minutes\` / \`vertical_update_tabs\` and their Settings controls.
- \`fontdb\` shared behind an \`Arc\` instead of deep-cloned per icon render.
- Build each tray status icon once instead of twice when animations are off.
- Removed the unused \`startCheck\` IPC export/import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)