### PR TITLE
feat: group updates list by repository

### DIFF
--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -465,6 +465,24 @@ mod tests {
     }
 
     #[test]
+    fn official_repos_matches_frontend_list() {
+        // OFFICIAL_REPOS is duplicated across the Rust/TS boundary (URL gating
+        // here, UI group ordering in src/lib/repo.ts). Parse the TS source and
+        // compare so the two copies can't silently drift.
+        let ts_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../src/lib/repo.ts");
+        let ts = std::fs::read_to_string(&ts_path).expect("read src/lib/repo.ts");
+        let block = ts
+            .split("OFFICIAL_REPOS = [")
+            .nth(1)
+            .and_then(|rest| rest.split(']').next())
+            .expect("OFFICIAL_REPOS array literal in repo.ts");
+        // String literals are every odd-indexed piece when splitting on quotes.
+        let ts_repos: Vec<&str> = block.split('"').skip(1).step_by(2).collect();
+        assert_eq!(ts_repos, OFFICIAL_REPOS);
+    }
+
+    #[test]
     fn maybe_kernel_pkg_excludes_userspace() {
         assert!(maybe_kernel_pkg("linux"));
         assert!(maybe_kernel_pkg("linux-zen"));

--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -215,7 +215,8 @@ pub fn parse_si_repositories(stdout: &str) -> HashMap<String, (String, String)> 
 
 /// Repos hosted on archlinux.org — only these get a package page URL. Packages
 /// from custom/self-hosted repos (e.g. a personal pacman repo) have no
-/// archlinux.org page, so linking there would 404.
+/// archlinux.org page, so linking there would 404. Must stay in sync with
+/// OFFICIAL_REPOS in src/lib/repo.ts, which orders the repo groups in the UI.
 static OFFICIAL_REPOS: &[&str] = &[
     "core",
     "extra",
@@ -223,6 +224,9 @@ static OFFICIAL_REPOS: &[&str] = &[
     "core-testing",
     "extra-testing",
     "multilib-testing",
+    "core-staging",
+    "extra-staging",
+    "multilib-staging",
     "kde-unstable",
     "gnome-unstable",
 ];
@@ -452,6 +456,9 @@ mod tests {
             package_url("extra", "x86_64", "firefox"),
             "https://archlinux.org/packages/extra/x86_64/firefox/"
         );
+        // Staging/testing/unstable variants are hosted on archlinux.org too.
+        assert!(!package_url("core-staging", "x86_64", "glibc").is_empty());
+        assert!(!package_url("kde-unstable", "x86_64", "plasma-desktop").is_empty());
         // Custom repos (e.g. a personal pacman repo) have no archlinux.org
         // page — the URL must stay empty so the UI hides the link.
         assert_eq!(package_url("paw", "x86_64", "some-tool"), "");

--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -213,8 +213,26 @@ pub fn parse_si_repositories(stdout: &str) -> HashMap<String, (String, String)> 
     repos
 }
 
-/// Build the archlinux.org package page URL for a repo package.
+/// Repos hosted on archlinux.org — only these get a package page URL. Packages
+/// from custom/self-hosted repos (e.g. a personal pacman repo) have no
+/// archlinux.org page, so linking there would 404.
+static OFFICIAL_REPOS: &[&str] = &[
+    "core",
+    "extra",
+    "multilib",
+    "core-testing",
+    "extra-testing",
+    "multilib-testing",
+    "kde-unstable",
+    "gnome-unstable",
+];
+
+/// Build the archlinux.org package page URL for an official repo package, or
+/// an empty string for custom-repo packages (the UI hides the link).
 pub fn package_url(repo: &str, arch: &str, package: &str) -> String {
+    if !OFFICIAL_REPOS.contains(&repo) {
+        return String::new();
+    }
     format!("https://archlinux.org/packages/{repo}/{arch}/{package}/")
 }
 
@@ -426,6 +444,17 @@ mod tests {
         // Running kernel unknown → any recognized kernel package is conservative.
         assert!(package_requires_restart("linux-zen", None));
         assert!(!package_requires_restart("firefox", None));
+    }
+
+    #[test]
+    fn package_url_only_for_official_repos() {
+        assert_eq!(
+            package_url("extra", "x86_64", "firefox"),
+            "https://archlinux.org/packages/extra/x86_64/firefox/"
+        );
+        // Custom repos (e.g. a personal pacman repo) have no archlinux.org
+        // page — the URL must stay empty so the UI hides the link.
+        assert_eq!(package_url("paw", "x86_64", "some-tool"), "");
     }
 
     #[test]

--- a/src/lib/components/DependencyTree.svelte
+++ b/src/lib/components/DependencyTree.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getPactree } from "../ipc";
+  import { repoColorVar } from "../repo";
 
   let {
     packageName,
@@ -69,7 +70,7 @@
     <div class="head">
       <span class="pkg">{packageName}</span>
       {#if repository}
-        <span class="repo" style={`--c: var(--ys-repo-${repository}, var(--ys-text-muted))`}>{repository}</span>
+        <span class="repo" style={`--c: ${repoColorVar(repository, "--ys-text-muted")}`}>{repository}</span>
       {/if}
       <div class="spacer"></div>
       <div class="seg">

--- a/src/lib/components/UpdateCard.svelte
+++ b/src/lib/components/UpdateCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { open as openUrl } from "@tauri-apps/plugin-shell";
   import type { UpdateInfo } from "../types";
+  import { repoColorVar } from "../repo";
   import VersionDiff from "./VersionDiff.svelte";
 
   let {
@@ -42,7 +43,7 @@
     <div class="name-row">
       <span class="pkg">{update.package}</span>
       {#if update.repository}
-        <span class="pbadge repo" style={`--c: var(--ys-repo-${update.repository}, var(--ys-text-muted))`}>
+        <span class="pbadge repo" style={`--c: ${repoColorVar(update.repository, "--ys-text-muted")}`}>
           {update.repository}
         </span>
       {/if}

--- a/src/lib/components/UpdatesDialog.svelte
+++ b/src/lib/components/UpdatesDialog.svelte
@@ -12,6 +12,7 @@
     runRemoteUpdatePackages,
     runUpdateSelected,
   } from "../ipc";
+  import { repoRank, repoColorVar } from "../repo";
   import UpdateCard from "./UpdateCard.svelte";
   import Reticle from "./Reticle.svelte";
   import DependencyTree from "./DependencyTree.svelte";
@@ -99,17 +100,6 @@
   let multiHost = $derived(hosts.length > 1);
   let activeHost = $derived(hosts.find((h) => h.key === activeKey) ?? hosts[0]);
   let activeSelected = $derived(selectedByHost[activeKey] ?? []);
-
-  // Official repos lead in pacman.conf order; custom repos (e.g. paw) follow
-  // alphabetically; AUR is last; packages with no known repo sink to the end.
-  const REPO_ORDER = ["core", "extra", "multilib", "core-testing", "extra-testing", "multilib-testing"];
-  function repoRank(repo: string): number {
-    const i = REPO_ORDER.indexOf(repo);
-    if (i !== -1) return i;
-    if (repo === "aur") return 200;
-    if (repo === "other") return 300;
-    return 100;
-  }
 
   type RepoGroup = { name: string; updates: UpdateInfo[] };
 
@@ -457,7 +447,7 @@
           {/each}
         {/if}
         {#each grouped.repos as r (r.name)}
-          <div class="section repo" style={`--c: var(--ys-repo-${r.name.replace(/[^a-zA-Z0-9-]/g, "-")}, var(--ys-pending))`}>
+          <div class="section repo" style={`--c: ${repoColorVar(r.name, "--ys-pending")}`}>
             <span class="sdot"></span>{r.name.toUpperCase()}
             <span class="scount">{r.updates.length}</span>
           </div>

--- a/src/lib/components/UpdatesDialog.svelte
+++ b/src/lib/components/UpdatesDialog.svelte
@@ -100,20 +100,47 @@
   let activeHost = $derived(hosts.find((h) => h.key === activeKey) ?? hosts[0]);
   let activeSelected = $derived(selectedByHost[activeKey] ?? []);
 
+  // Official repos lead in pacman.conf order; custom repos (e.g. paw) follow
+  // alphabetically; AUR is last; packages with no known repo sink to the end.
+  const REPO_ORDER = ["core", "extra", "multilib", "core-testing", "extra-testing", "multilib-testing"];
+  function repoRank(repo: string): number {
+    const i = REPO_ORDER.indexOf(repo);
+    if (i !== -1) return i;
+    if (repo === "aur") return 200;
+    if (repo === "other") return 300;
+    return 100;
+  }
+
+  type RepoGroup = { name: string; updates: UpdateInfo[] };
+
   let grouped = $derived.by(() => {
     const h = activeHost;
-    if (!h) return { restart: [] as UpdateInfo[], normal: [] as UpdateInfo[] };
+    if (!h) return { restart: [] as UpdateInfo[], repos: [] as RepoGroup[] };
     const q = search.toLowerCase();
     const ups = h.updates.filter((u) => !q || u.package.toLowerCase().includes(q));
     const rset = new Set(h.restartPkgs);
     const byName = (a: UpdateInfo, b: UpdateInfo) => a.package.localeCompare(b.package);
+    const byRepo = new Map<string, UpdateInfo[]>();
+    for (const u of ups) {
+      if (rset.has(u.package)) continue;
+      const repo = u.repository || "other";
+      const group = byRepo.get(repo);
+      if (group) group.push(u);
+      else byRepo.set(repo, [u]);
+    }
+    const repos = [...byRepo.entries()]
+      .map(([name, updates]) => ({ name, updates: updates.sort(byName) }))
+      .sort((a, b) => repoRank(a.name) - repoRank(b.name) || a.name.localeCompare(b.name));
     return {
       restart: ups.filter((u) => rset.has(u.package)).sort(byName),
-      normal: ups.filter((u) => !rset.has(u.package)).sort(byName),
+      repos,
     };
   });
 
-  let visiblePkgs = $derived([...grouped.restart, ...grouped.normal].map((u) => u.package));
+  let visiblePkgs = $derived([
+    ...grouped.restart,
+    ...grouped.repos.flatMap((r) => r.updates),
+  ].map((u) => u.package));
   let selCount = $derived(activeSelected.length);
   let allSelected = $derived(visiblePkgs.length > 0 && visiblePkgs.every((p) => activeSelected.includes(p)));
   let primaryLabel = $derived.by(() => {
@@ -429,9 +456,12 @@
             />
           {/each}
         {/if}
-        {#if grouped.normal.length > 0}
-          <div class="section all"><span class="sdot"></span>ALL UPDATES</div>
-          {#each grouped.normal as u (u.package)}
+        {#each grouped.repos as r (r.name)}
+          <div class="section repo" style={`--c: var(--ys-repo-${r.name.replace(/[^a-zA-Z0-9-]/g, "-")}, var(--ys-pending))`}>
+            <span class="sdot"></span>{r.name.toUpperCase()}
+            <span class="scount">{r.updates.length}</span>
+          </div>
+          {#each r.updates as u (u.package)}
             <UpdateCard
               update={u}
               compact={density === "compact"}
@@ -441,7 +471,7 @@
               onShowDeps={(reverse) => (showDeps = { pkg: u.package, reverse, repo: u.repository, host: activeKey === "local" ? null : activeKey })}
             />
           {/each}
-        {/if}
+        {/each}
       </main>
     </div>
 
@@ -589,7 +619,12 @@
   .sdot { width: 6px; height: 6px; border-radius: 50%; }
   .section.restart { color: var(--ys-danger); }
   .section.restart .sdot { background: var(--ys-danger); }
-  .section.all .sdot { background: var(--ys-pending); }
+  .section.repo .sdot { background: var(--c, var(--ys-pending)); }
+  .scount {
+    font-family: var(--font-mono); font-weight: 600; font-size: 10px;
+    color: var(--ys-text-dim); background: var(--ys-surface);
+    border-radius: 7px; padding: 0 6px;
+  }
 
   .footer {
     display: flex; align-items: center; justify-content: space-between;

--- a/src/lib/components/UpdatesDialog.svelte
+++ b/src/lib/components/UpdatesDialog.svelte
@@ -12,7 +12,7 @@
     runRemoteUpdatePackages,
     runUpdateSelected,
   } from "../ipc";
-  import { repoRank, repoColorVar } from "../repo";
+  import { repoRank, repoColorVar, UNKNOWN_REPO } from "../repo";
   import UpdateCard from "./UpdateCard.svelte";
   import Reticle from "./Reticle.svelte";
   import DependencyTree from "./DependencyTree.svelte";
@@ -105,32 +105,31 @@
 
   let grouped = $derived.by(() => {
     const h = activeHost;
-    if (!h) return { restart: [] as UpdateInfo[], repos: [] as RepoGroup[] };
+    if (!h) return { restart: [] as UpdateInfo[], repos: [] as RepoGroup[], visible: [] as UpdateInfo[] };
     const q = search.toLowerCase();
     const ups = h.updates.filter((u) => !q || u.package.toLowerCase().includes(q));
     const rset = new Set(h.restartPkgs);
     const byName = (a: UpdateInfo, b: UpdateInfo) => a.package.localeCompare(b.package);
+    const restart: UpdateInfo[] = [];
     const byRepo = new Map<string, UpdateInfo[]>();
     for (const u of ups) {
-      if (rset.has(u.package)) continue;
-      const repo = u.repository || "other";
+      if (rset.has(u.package)) {
+        restart.push(u);
+        continue;
+      }
+      const repo = u.repository || UNKNOWN_REPO;
       const group = byRepo.get(repo);
       if (group) group.push(u);
       else byRepo.set(repo, [u]);
     }
+    restart.sort(byName);
     const repos = [...byRepo.entries()]
       .map(([name, updates]) => ({ name, updates: updates.sort(byName) }))
       .sort((a, b) => repoRank(a.name) - repoRank(b.name) || a.name.localeCompare(b.name));
-    return {
-      restart: ups.filter((u) => rset.has(u.package)).sort(byName),
-      repos,
-    };
+    return { restart, repos, visible: [...restart, ...repos.flatMap((r) => r.updates)] };
   });
 
-  let visiblePkgs = $derived([
-    ...grouped.restart,
-    ...grouped.repos.flatMap((r) => r.updates),
-  ].map((u) => u.package));
+  let visiblePkgs = $derived(grouped.visible.map((u) => u.package));
   let selCount = $derived(activeSelected.length);
   let allSelected = $derived(visiblePkgs.length > 0 && visiblePkgs.every((p) => activeSelected.includes(p)));
   let primaryLabel = $derived.by(() => {

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -18,15 +18,23 @@ export const OFFICIAL_REPOS = [
   "gnome-unstable",
 ];
 
-// Sort key for repo groups: official repos lead in the order above; custom
-// repos (e.g. paw) follow alphabetically; AUR is last; "other" (packages with
-// no known repo) sinks below AUR.
+// Sentinel group name for packages whose repo couldn't be determined. Shared
+// with the grouping in UpdatesDialog so the rank below can't desync from it.
+export const UNKNOWN_REPO = "other";
+
+// Rank tiers, derived from the list length so they can never collide with an
+// official repo's index: official repos lead in the order above, then custom
+// repos (e.g. paw, alphabetized by the caller), then AUR, then unknown last.
+const TIER_CUSTOM = OFFICIAL_REPOS.length;
+const TIER_AUR = TIER_CUSTOM + 1;
+const TIER_UNKNOWN = TIER_CUSTOM + 2;
+
 export function repoRank(repo: string): number {
   const i = OFFICIAL_REPOS.indexOf(repo);
   if (i !== -1) return i;
-  if (repo === "aur") return 200;
-  if (repo === "other") return 300;
-  return 100;
+  if (repo === "aur") return TIER_AUR;
+  if (repo === UNKNOWN_REPO) return TIER_UNKNOWN;
+  return TIER_CUSTOM;
 }
 
 // Build the var() reference for a repo's theme color. Repo names may contain

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -1,0 +1,39 @@
+// Repo-related helpers shared by the updates list, update cards, and the
+// dependency tree, so grouping order and badge colors always agree.
+
+// Repos hosted on archlinux.org, in pacman.conf order. Must stay in sync with
+// OFFICIAL_REPOS in src-tauri/src/checker.rs, which uses the same list to
+// decide which packages get an archlinux.org package-page URL.
+export const OFFICIAL_REPOS = [
+  "core",
+  "extra",
+  "multilib",
+  "core-testing",
+  "extra-testing",
+  "multilib-testing",
+  "core-staging",
+  "extra-staging",
+  "multilib-staging",
+  "kde-unstable",
+  "gnome-unstable",
+];
+
+// Sort key for repo groups: official repos lead in the order above; custom
+// repos (e.g. paw) follow alphabetically; AUR is last; "other" (packages with
+// no known repo) sinks below AUR.
+export function repoRank(repo: string): number {
+  const i = OFFICIAL_REPOS.indexOf(repo);
+  if (i !== -1) return i;
+  if (repo === "aur") return 200;
+  if (repo === "other") return 300;
+  return 100;
+}
+
+// Build the var() reference for a repo's theme color. Repo names may contain
+// characters illegal in a CSS custom-property name (e.g. "."), which would
+// void the whole style declaration — sanitize here so every call site keys
+// off the same variable name.
+export function repoColorVar(repo: string, fallbackVar: string): string {
+  const slug = repo.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `var(--ys-repo-${slug}, var(${fallbackVar}))`;
+}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -14,7 +14,9 @@ const mkUpdates = () => [
   { package: "android-tools", old_version: "35.0.2-27", new_version: "35.0.2-28", description: "Android platform tools", repository: "extra", url: "" },
   { package: "grpc", old_version: "1.81.0-1", new_version: "1.81.1-1", description: "", repository: "extra", url: "" },
   { package: "lib32-systemd", old_version: "260.2-1", new_version: "261-1", description: "", repository: "multilib", url: "" },
+  { package: "yt-transcript", old_version: "0.3.1-1", new_version: "0.4.0-1", description: "YouTube transcript fetcher", repository: "paw", url: "" },
   { package: "kitinerary", old_version: "26.04.2-3", new_version: "26.04.2-4", description: "itinerary extractor", repository: "aur", url: "https://aur.archlinux.org" },
+  { package: "mystery-tool", old_version: "1.0-1", new_version: "1.1-1", description: "package with unknown repo", repository: "", url: "" },
 ];
 
 const config = {


### PR DESCRIPTION
## Summary
- Keep the **Restart Required** section, but split the rest of the updates list into per-repo sections (core, extra, multilib, custom repos like paw, aur) instead of one flat "All Updates" group
- Sections are ordered official repos first, then custom repos alphabetically, then AUR, with an **OTHER** group for packages whose repo couldn't be determined; each header shows a count and reuses the existing `--ys-repo-*` badge colors for its dot
- Fix: stop building `archlinux.org/packages/...` URLs for packages from non-official repos (e.g. a personal pacman repo) — those pages don't exist so the link 404'd; the card already hides the web button when the URL is empty
- Preview harness: add a paw package and a repo-less package to the mock data so both new group types render

## Testing
- `cargo test` — 10/10 pass (includes a new `package_url_only_for_official_repos` test)
- `svelte-check` — 0 errors
- Screenshotted the preview harness: RESTART REQUIRED → EXTRA → MULTILIB → PAW → AUR → OTHER all render with correct counts, colors, and cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)